### PR TITLE
Initialize gettext support

### DIFF
--- a/src/applet.c
+++ b/src/applet.c
@@ -150,6 +150,11 @@ static void brisk_menu_applet_class_init(BriskMenuAppletClass *klazz)
  */
 static void brisk_menu_applet_init(BriskMenuApplet *self)
 {
+        setlocale (LC_ALL, "");
+        bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
+        bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        textdomain (GETTEXT_PACKAGE);
+
         GtkWidget *toggle, *layout, *image, *label, *menu = NULL;
 
         self->binder = brisk_key_binder_new();

--- a/src/applet.c
+++ b/src/applet.c
@@ -150,10 +150,10 @@ static void brisk_menu_applet_class_init(BriskMenuAppletClass *klazz)
  */
 static void brisk_menu_applet_init(BriskMenuApplet *self)
 {
-        setlocale (LC_ALL, "");
-        bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
-        bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-        textdomain (GETTEXT_PACKAGE);
+        setlocale(LC_ALL, "");
+        bindtextdomain(GETTEXT_PACKAGE, MATELOCALEDIR);
+        bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
+        textdomain(GETTEXT_PACKAGE);
 
         GtkWidget *toggle, *layout, *image, *label, *menu = NULL;
 


### PR DESCRIPTION
Translation not works without initialization.
See https://developer.gnome.org/glib/stable/glib-I18N.html
In addition, all po files contains "Content-Type: text/plain; charset=CHARSET\n", which is invalid.
(Also on transifex.)