### PR TITLE
Correct inverted bitwise operators for search bar placement. Closes #19

### DIFF
--- a/src/menu-private.h
+++ b/src/menu-private.h
@@ -22,9 +22,9 @@
 
 typedef enum {
         SEARCH_POS_MIN = 0,
-        SEARCH_POS_AUTOMATIC = 1 << 0,
+        SEARCH_POS_BOTTOM = 1 << 0,
         SEARCH_POS_TOP = 1 << 1,
-        SEARCH_POS_BOTTOM = 1 << 2,
+        SEARCH_POS_AUTOMATIC = 1 << 2,
         SEARCH_POS_MAX,
 } SearchPosition;
 


### PR DESCRIPTION
The bitwise operators for calculating the search bar placement are inverted. This pull request swaps `SEARCH_POS_AUTOMATIC` and `SEARCH_POS_BOTTOM` to correspond with `com.solus-project.brisk-menu.SearchPosition`.