### PR TITLE
Add the ability to change the menu button label text via gsettings

### DIFF
--- a/data/com.solus-project.brisk-menu.gschema.xml
+++ b/data/com.solus-project.brisk-menu.gschema.xml
@@ -31,5 +31,10 @@
       <summary>Keyboard shortcut</summary>
       <description>Accelerator key for opening and closing the menu.</description>
     </key>
+    <key type="s" name="label-text">
+      <default>""</default>
+      <summary>Button label text</summary>
+      <description>Change the label text for the menu button</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
This commit adds the label-text key to the menu settings, which is used
to change the label text of the menu button. If the key value is empty,
it uses the default text (from the translations).

Fixes #13
