### PR TITLE
Add check for intltoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,15 @@ PKG_NAME="brisk-menu"
 prevdir="$PWD"
 cd "$srcdir"
 
-intltoolize --force
+INTLTOOLIZE=`which intltoolize`
+if test -z $INTLTOOLIZE;
+then
+  echo "*** No intltoolize found, please install it ***"
+  exit 1
+else
+  intltoolize --force
+fi
+
 AUTORECONF=`which autoreconf`
 if test -z $AUTORECONF;
 then


### PR DESCRIPTION
On Fedora 26, the following error occured when running `./autogen.sh --prefix=/usr` without intltoolize installed, https://gist.github.com/greenmanspirit/95a56abaf81ac11d68c8d21eb1ebe4db. I fixed this by adding a check for intltoolize like there is for autoreconf.