### PR TITLE
po: Force UTF-8, again

### DIFF
--- a/po/brisk-menu.pot
+++ b/po/brisk-menu.pot
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/backend/all-items/all-backend.c:52


### PR DESCRIPTION
Regenerating brisk-menu.pot reverted charset back to the generic CHARSET.
When building brisk-menu, at least for me, the application doesn't get
localized unless manually reverting this back to UTF-8.

I have yet to find a way to configure meson to generate UTF-8 po templates,
and the meson documentation mentions nothing of the sort.

Signed-off-by: Kim Malmo <berencamlost@msn.com>