### PR TITLE
Fix dash styling for some light themes

### DIFF
--- a/data/brisk.gresource.xml
+++ b/data/brisk.gresource.xml
@@ -3,5 +3,6 @@
         <gresource prefix="/com/solus-project/brisk/menu">
                 <file>classic/styling.css</file>
                 <file>dash/styling.css</file>
+                <file>dash/styling-light.css</file>
         </gresource>
 </gresources>

--- a/data/dash/styling-light.css
+++ b/data/dash/styling-light.css
@@ -9,7 +9,7 @@
 }
 
 .brisk-dash {
-	background-color: alpha(@theme_bg_color, 0.95);
+	background-color: alpha(@dark_bg_color, 0.95);
 }
 
 .brisk-dash .dash-category-button {
@@ -19,19 +19,19 @@
 }
 
 .brisk-dash .dash-category-button:checked {
-	background-color: mix(@theme_bg_color, #000000, 0.2);
-	border: 1px solid alpha(@theme_fg_color, 0.1);
+	background-color: mix(@dark_bg_color, #000000, 0.2);
+	border: 1px solid alpha(@dark_fg_color, 0.1);
 }
 
 .brisk-dash .dash-category-button:hover {
-	background-color: mix(@theme_bg_color, #000000, 0.2);
+	background-color: mix(@dark_bg_color, #000000, 0.2);
 	border: 1px solid alpha(#000, 0.2);
 }
 
 .brisk-dash .header {
-	background-color: mix(@theme_bg_color, #000000, 0.1);
-    border-bottom: 1px solid mix(@theme_base_color, #000000,  0.35);
-    box-shadow: 0px 1px 1px alpha(@theme_fg_color, 0.04);
+	background-color: mix(@dark_bg_color, #000000, 0.1);
+    border-bottom: 1px solid mix(@dark_bg_color, #000000,  0.35);
+    box-shadow: 0px 1px 1px alpha(@dark_fg_color, 0.04);
 }
 
 .brisk-dash .header .section-box-holder {


### PR DESCRIPTION
Use a different style for light themes that set @dark_{bg,fg}_color.
This fixes #82