### PR TITLE
Fix super key global bindings on compiz

### DIFF
--- a/src/lib/key-binder.c
+++ b/src/lib/key-binder.c
@@ -183,6 +183,8 @@ static GdkFilterReturn brisk_key_binder_filter(GdkXEvent *xevent, GdkEvent *even
                         }
                         XAllowEvents(display, AsyncKeyboard, xev->xkey.time);
                 } else {
+                        XAllowEvents(display, ReplayKeyboard, xev->xkey.time);
+                        XUngrabKeyboard(display, xev->xkey.time);
                         /* when breaking the shortcut sequence, send the event up the window
                          * hierarchy in case it's part of a different shortcut sequence
                          * (e.g. <Mod4>a) */
@@ -191,7 +193,6 @@ static GdkFilterReturn brisk_key_binder_filter(GdkXEvent *xevent, GdkEvent *even
                                    TRUE,
                                    KeyPressMask | KeyReleaseMask,
                                    xev);
-                        XAllowEvents(display, ReplayKeyboard, xev->xkey.time);
                         self->wait_for_release = FALSE;
                 }
         }


### PR DESCRIPTION
This adds an XUngrabKeyboard call so that Compiz can receive proper key events.

It also cleans up the code and removes unnecessary XAllowEvents.

Related:
* mate-desktop/mate-settings-daemon/pull/216
* ubuntu-mate/mate-menu/pull/33