### PR TITLE
Update to new API from mate-menus 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ brisk-menu is **distro-agnostic** and the reporting of portability issues is enc
 
 ![screenshot](https://raw.githubusercontent.com/solus-project/brisk-menu/master/.github/main.png)
 
-brisk-menu is a **collaborative** project between [Solus](https://solus-project.com/) and [Ubuntu MATE](https://ubuntu-mate.org/)
+brisk-menu is a **collaborative** project between [Solus](https://getsol.us/) and [Ubuntu MATE](https://ubuntu-mate.org/)
 
-![ubuntu_mate_logo](https://ubuntu-mate.org/gallery/Artwork/design-guide/Main_Logo.png) ![solus_logo](https://build.solus-project.com/logo.png)
+![ubuntu_mate_logo](https://ubuntu-mate.org/gallery/Artwork/design-guide/Main_Logo.png) ![solus_logo](https://build.getsol.us/logo.png)
 
 Features
 --------

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ gnome = import('gnome')
 
 # Required minimum versions
 gtk_min_version = '>= 3.18.0'
-mate_min_version = '>= 1.16.0'
+mate_min_version = '>= 1.21.0'
 glib_min_version = '>= 2.44.0'
 
 # GTK/UI deps

--- a/src/backend/apps/apps-section.c
+++ b/src/backend/apps/apps-section.c
@@ -54,48 +54,22 @@ static const GIcon *brisk_apps_section_get_icon(BriskSection *item);
 static const gchar *brisk_apps_section_get_backend_id(BriskSection *item);
 static gboolean brisk_apps_section_can_show_item(BriskSection *section, BriskItem *item);
 
-/**
- * Create a GIcon for the given path
- */
-static GIcon *brisk_apps_section_create_path_icon(const gchar *path)
-{
-        autofree(GFile) *file = NULL;
-
-        file = g_file_new_for_path(path);
-        if (!file) {
-                return NULL;
-        }
-        return g_file_icon_new(file);
-}
-
 static void brisk_apps_section_update_directory(BriskAppsSection *self,
                                                 MateMenuTreeDirectory *directory)
 {
         g_clear_object(&self->icon);
         g_clear_pointer(&self->id, g_free);
         g_clear_pointer(&self->name, g_free);
-        const gchar *icon = NULL;
 
         if (!directory) {
                 return;
         }
 
-        /* Set our ID and name */
+        /* Set our ID, name, and icon */
         self->id =
             g_strdup_printf("%s.mate-directory", matemenu_tree_directory_get_menu_id(directory));
         self->name = g_strdup(matemenu_tree_directory_get_name(directory));
-
-        icon = matemenu_tree_directory_get_icon(directory);
-        if (!icon) {
-                return;
-        }
-
-        /* Set an appropriate icon based on the string */
-        if (icon[0] == '/') {
-                self->icon = brisk_apps_section_create_path_icon(icon);
-        } else {
-                self->icon = g_themed_icon_new_with_default_fallbacks(icon);
-        }
+        self->icon = matemenu_tree_directory_get_icon(directory);
 }
 
 static void brisk_apps_section_set_property(GObject *object, guint id, const GValue *value,

--- a/src/backend/apps/apps-section.h
+++ b/src/backend/apps/apps-section.h
@@ -13,6 +13,8 @@
 
 #include <gio/gio.h>
 #include <glib-object.h>
+
+#define MATEMENU_I_KNOW_THIS_IS_UNSTABLE
 #include <matemenu-tree.h>
 
 #include "../section.h"

--- a/src/frontend/classic/desktop-button.h
+++ b/src/frontend/classic/desktop-button.h
@@ -13,7 +13,6 @@
 
 #include <glib-object.h>
 #include <gtk/gtk.h>
-#include <matemenu-tree.h>
 
 #include "launcher.h"
 

--- a/src/frontend/menu-keyboard.c
+++ b/src/frontend/menu-keyboard.c
@@ -23,12 +23,17 @@ gboolean brisk_menu_window_key_press(BriskMenuWindow *self, GdkEvent *event,
                                      __brisk_unused__ gpointer v)
 {
         autofree(gchar) *accel_name = NULL;
+        GdkModifierType lock_masks = GDK_MOD2_MASK | GDK_LOCK_MASK | GDK_MOD5_MASK;
+        guint mods;
 
         if (!self->shortcut) {
                 return GDK_EVENT_PROPAGATE;
         }
 
-        accel_name = gtk_accelerator_name(event->key.keyval, event->key.state);
+        /* Unset mask of the lock keys */
+        mods = event->key.state & ~(lock_masks);
+
+        accel_name = gtk_accelerator_name(event->key.keyval, mods);
         if (!accel_name || g_ascii_strcasecmp(self->shortcut, accel_name) != 0) {
                 return GDK_EVENT_PROPAGATE;
         }


### PR DESCRIPTION
This may be considered work in progress. The mate-menus project has been updated and has breaking API changes. This pull request updates Brisk to support the new API, but until all necessary dependencies have been tagged appropriately (and 1.21 is a dev version), it might not make sense to merge this.

I will update this as necessary.

Fixes #115 