### PR TITLE
Make favorites appear first

### DIFF
--- a/src/frontend/menu-loader.c
+++ b/src/frontend/menu-loader.c
@@ -143,8 +143,8 @@ void brisk_menu_window_remove_category(GtkWidget *widget, BriskMenuWindow *self)
  */
 void brisk_menu_window_init_backends(BriskMenuWindow *self)
 {
-        brisk_menu_window_insert_backend(self, brisk_all_items_backend_new());
         brisk_menu_window_insert_backend(self, brisk_favourites_backend_new());
+        brisk_menu_window_insert_backend(self, brisk_all_items_backend_new());
         brisk_menu_window_insert_backend(self, brisk_apps_backend_new());
 }
 


### PR DESCRIPTION
Fixes #100 

Ideally this should be configurable before merging, but I'm not sure if there's any use case where showing "All" by default is useful.